### PR TITLE
Allow proc as option value for has_global_records

### DIFF
--- a/lib/acts_as_tenant.rb
+++ b/lib/acts_as_tenant.rb
@@ -11,7 +11,7 @@ module ActsAsTenant
 
   @@configuration = nil
   @@tenant_klass = nil
-  @@models_with_global_records = []
+  @@models_with_global_records = {}
 
   class << self
     attr_writer :default_tenant
@@ -39,8 +39,14 @@ module ActsAsTenant
     @@models_with_global_records
   end
 
-  def self.add_global_record_model model
-    @@models_with_global_records.push(model)
+  def self.add_global_record_model model, value
+    @@models_with_global_records[model.name] = value
+  end
+
+  def self.has_global_records? model
+    value = @@models_with_global_records[model.name]
+
+    value.is_a?(Proc) ? value.call : value
   end
 
   def self.fkey

--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -6,7 +6,7 @@ module ActsAsTenant
       def acts_as_tenant(tenant = :account, **options)
         ActsAsTenant.set_tenant_klass(tenant)
 
-        ActsAsTenant.add_global_record_model(self) if options[:has_global_records]
+        ActsAsTenant.add_global_record_model(self, options[:has_global_records])
 
         # Create the association
         valid_options = options.slice(:foreign_key, :class_name, :inverse_of, :optional, :primary_key, :counter_cache)
@@ -27,7 +27,7 @@ module ActsAsTenant
 
           if ActsAsTenant.current_tenant
             keys = [ActsAsTenant.current_tenant.send(pkey)].compact
-            keys.push(nil) if options[:has_global_records]
+            keys.push(nil) if ActsAsTenant.has_global_records?(self.klass)
 
             if options[:through]
               query_criteria = {options[:through] => {fkey.to_sym => keys}}
@@ -131,7 +131,7 @@ module ActsAsTenant
         # validating within tenant scope
         validates_uniqueness_of(fields, validation_args)
 
-        if ActsAsTenant.models_with_global_records.include?(self)
+        if ActsAsTenant.has_global_records?(self)
           arg_if = args.delete(:if)
           arg_condition = args.delete(:conditions)
 


### PR DESCRIPTION
This is so that we can evaluate it at runtime; especially useful for
tests so that we can easily test the different environments without
resorting to reloading classes, etc.