### PR TITLE
Fix global record validations with existing scope

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -121,9 +121,9 @@ module ActsAsTenant
 
         fkey = reflect_on_association(ActsAsTenant.tenant_klass).foreign_key
 
-        validation_args = args.clone
+        validation_args = args.deep_dup
         validation_args[:scope] = if args[:scope]
-          Array(args[:scope]) << fkey
+          Array(args[:scope]) + [fkey]
         else
           fkey
         end

--- a/spec/dummy/app/models/global_project_with_scope.rb
+++ b/spec/dummy/app/models/global_project_with_scope.rb
@@ -1,0 +1,6 @@
+class GlobalProjectWithScope < ActiveRecord::Base
+  self.table_name = "projects"
+
+  acts_as_tenant :account, has_global_records: true
+  validates_uniqueness_to_tenant :name, scope: [:user_defined_scope]
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 1) do
   create_table :projects, force: true do |t|
     t.column :name, :string
     t.column :account_id, :integer
+    t.column :user_defined_scope, :string
   end
 
   create_table :managers, force: true do |t|

--- a/spec/fixtures/global_projects.yml
+++ b/spec/fixtures/global_projects.yml
@@ -11,3 +11,7 @@ global_foo:
 global_bar:
   account: bar
   name: "global bar"
+
+global_scope:
+  name: "global scope"
+  user_defined_scope: abc

--- a/spec/models/model_extensions_spec.rb
+++ b/spec/models/model_extensions_spec.rb
@@ -164,6 +164,14 @@ describe ActsAsTenant do
       it "is invalid if tenant record conflicts with global record" do
         expect(GlobalProject.new(name: "global").valid?).to be(false)
       end
+
+      it "is invalid if tenant record conflicts with global record with scope" do
+        duplicate = GlobalProjectWithScope.new(
+          name: "global scope",
+          user_defined_scope: "abc"
+        )
+        expect(duplicate.valid?).to be(false)
+      end
     end
 
     context "should validate global records against global & tenant records" do


### PR DESCRIPTION
Due to how the `args` object was being (man)handled, we were leaking
the tenant scope into the global scope validation where it shouldn't
have been. This only happened when there was a scope argument supplied
to validates_uniquness_to_tenant.